### PR TITLE
responsive 默认值是 true 而不是 false

### DIFF
--- a/docs/components/Button.md
+++ b/docs/components/Button.md
@@ -59,5 +59,5 @@ class App extends React.Component {
 | ---- | ---- | ---- | ---- | ---- |
 | type | String | true | null | 指明按钮的预定义样式，`default` `primary` `success` `info` `warning` `danger` `disabled`  |
 | size | String | false | 'md' | 尺寸，`lg` `md` `sm` |
-| responsive | Boolean | false | false | 是否拉伸至父组件 100% 宽度 |
+| responsive | Boolean | false | true | 是否拉伸至父组件 100% 宽度 |
 | onPress | Function | false | null | 点击回调 |


### PR DESCRIPTION
看了 ./components/Button/index.js 下的代码，发现 responsive 默认值为 true，跟文档描述有差异。

```js
export default class Button extends React.Component {
    static propTypes = {
    };
    static defaultProps = {
        type: 'default',
        size: 'md',
        style: {},
        textColorReverse: false,
        responsive: true,
        onPress: () => {},
    };
    // ....
}
```